### PR TITLE
Fix syntax formatting on supabase.yml

### DIFF
--- a/public/v4/apps/supabase.yml
+++ b/public/v4/apps/supabase.yml
@@ -5,11 +5,11 @@ services:
         volumes:
             - $$cap_appname-kong-config:/var/lib/kong
         restart: always
-         ports:
-             - $$cap_kong_http_port:8000
-             - $$cap_kong_https_port:8443
-             - $$cap_kong_admin_port:8001
-             - $$cap_kong_admin_ssl_port:8444
+        ports:
+            - $$cap_kong_http_port:8000
+            - $$cap_kong_https_port:8443
+            - $$cap_kong_admin_port:8001
+            - $$cap_kong_admin_ssl_port:8444
         environment:
             KONG_DATABASE: $$cap_kong_database
             # https://github.com/supabase/cli/issues/14


### PR DESCRIPTION
There was an extra space added to the indent of the kong service ports that was causing invalid yaml syntax.

First of all, thank you for your contribution! 😄


### ☑️ Self Check before Merge

- [ ] I have tested the template using the method described in README.md thoroughly
- [ ] I have ensured that I put as much default values as possible (except passwords) to ensure minimum effort required for end users to get started.
- [ ] I have ensured that I am not using the "latest" tag as this tag is dynamically changing and might break the one-click app. Use a fixed version.
- [ ] I have made sure that instructions.start and instructions.end are clear and self-explanatory.
- [ ] Icon is added as a png file to the logos directory.
